### PR TITLE
Achieve compatibility with ppxlib 0.22.0

### DIFF
--- a/OCanren-ppx.opam
+++ b/OCanren-ppx.opam
@@ -20,7 +20,7 @@ depends: [
   "ocaml"
   "dune"              { >= "2.5"  }
   "dune-configurator"
-  "ppxlib"
+  "ppxlib"            { >= "0.22.0" }
   "base"
 ]
 

--- a/ppx/distrib/ppx_distrib_expander.ml
+++ b/ppx/distrib/ppx_distrib_expander.ml
@@ -270,7 +270,7 @@ let revisit_adt ~loc other_attrs tdecl ctors =
       let fully_abstract_typ =
         (* a type name for which we will generate `fmap` *)
         let extra_params = FoldInfo.map mapa
-          ~f:(fun fi -> (Ast_helper.Typ.var fi.FoldInfo.param_name, Asttypes.Invariant))
+          ~f:(fun fi -> (Ast_helper.Typ.var fi.FoldInfo.param_name, (Asttypes.NoVariance, Asttypes.NoInjectivity)))
         in
         let open Location in
         {full_t with ptype_params = full_t.ptype_params @ extra_params;


### PR DESCRIPTION
In ppxlib 0.22.0, the AST gets bumped to ocaml 4.12. This commit adapts
to the compiler changes from 4.11 to 4.12: mainly, the introduction of
injectivity to type declarations.

It would be good to merge this PR when ppxlib 0.22.0 gets released, which will be soon.

cc @NathanReb