### PR TITLE
Fix ppxlib constraint

### DIFF
--- a/OCanren-ppx.opam
+++ b/OCanren-ppx.opam
@@ -35,7 +35,7 @@ depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.10"}
   "dune-configurator"
-  "ppxlib" {>= "0.22" & <= "0.24"}
+  "ppxlib" {>= "0.22 & < "0.25.0"}
   "base"
   "ppx_inline_test"
   "ppx_expect"


### PR DESCRIPTION
In the opam ordering, 0.24 is considered strictly smaller than 0.24.0. So the constraint "<= 0.24" also excludes all 0.24.x versions.